### PR TITLE
Add Cloudinary storage backend for image uploads

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -34,6 +34,8 @@ INSTALLED_APPS = [
     "pages",
     "accounts",
     "spins",
+     "cloudinary",
+    "cloudinary_storage",
 ]
 
 MIDDLEWARE = [
@@ -133,3 +135,13 @@ DEFAULT_FILE_STORAGE = 'cloudinary_storage.storage.MediaCloudinaryStorage'
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
+
+
+
+CLOUDINARY_STORAGE = {
+    "CLOUD_NAME": os.environ.get("CLOUDINARY_CLOUD_NAME"),
+    "API_KEY": os.environ.get("CLOUDINARY_API_KEY"),
+    "API_SECRET": os.environ.get("CLOUDINARY_API_SECRET"),
+}
+
+DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"


### PR DESCRIPTION
Description:
This PR sets up Cloudinary as the default storage backend for media files in the Now Spinning app. The goal is to ensure uploaded images (such as avatars) are reliably stored and accessible in production.

Changes include:
Added Cloudinary storage configuration to settings.py
Updated DEFAULT_FILE_STORAGE to use cloudinary_storage.storage.MediaCloudinaryStorage
Added environment variables for CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET
Verified integration with the avatar ImageField in the user model

Why:
Previously, user-uploaded avatars weren’t loading in production because Render’s ephemeral filesystem clears uploads on deploy. Cloudinary fixes this by providing persistent cloud storage for media files.

Next steps (optional):
Test uploads in production and confirm accessibility